### PR TITLE
Batched run_multiple function

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Textkernel BV
+Copyright (c) 2020 Textkernel BV
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -45,4 +45,4 @@ welcome there.
 Documentation
 =============
 
-The full API documentation lives at https://neo4j-connector.readthedocs.io
+The documentation (including changelog) lives at https://neo4j-connector.readthedocs.io

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ copyright = '2019, Jelle Jan Bankert (Textkernel B.V.)'
 author = 'Jelle Jan Bankert (Textkernel B.V.)'
 
 # The short X.Y version
-version = '1.0'
+version = '1.1'
 # The full version, including alpha/beta/rc tags
-release = '1.0.1'
+release = '1.1.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Welcome to neo4j-connector's documentation!
 
    source/neo4j
    source/readme
+   source/changelog
 
 
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,18 @@
+*********
+Changelog
+*********
+
+1.1.0
+=====
+* the :code:`run_multiple` connector method now takes the :code:`batch_size` parameter. If the method gets more
+  statements than :code:`batch_size` then the statements are split over multiple HTTP requests. The :code:`run_multiple`
+  method still returns a single list with the responses from all batches. This parameter can help make large jobs
+  manageable for Neo4j (e.g not running out of memory).
+
+1.0.1
+=====
+* Improved documentation
+
+1.0.0
+=====
+* Initial release

--- a/docs/source/neo4j.rst
+++ b/docs/source/neo4j.rst
@@ -1,8 +1,9 @@
+*************
 neo4j package
-=============
+*************
 
 Module contents
----------------
+===============
 
 .. automodule:: neo4j
     :members:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as requirements_file:
 
 setup(
     name='neo4j-connector',
-    version='1.0.1',
+    version='1.1.0',
     description='Connector with single-request transactions for Neo4j 3.0 and above',
     long_description=long_description,
     long_description_content_type="text/x-rst",
@@ -26,6 +26,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Database",
         "Topic :: Software Development",
         "Topic :: Utilities",

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -112,3 +112,20 @@ class PostingStatementsTestCase(TestCase):
 
         statement_2_first_row = response[1][0]
         self.assertEqual(statement_2_first_row['key-cypher-2'], 'value-cypher-2')
+
+        # check that post has been called 1 times (i.e. all statements in a single post request)
+        self.assertEqual(mock_get.call_count, 1)
+
+    @mock.patch('neo4j.requests.post', side_effect=mock_requests_post)
+    def test_run_multiple_batch(self, mock_get):
+        statements = [neo4j.Statement(self.cypher1), neo4j.Statement(self.cypher2)]
+        response = self.connector.run_multiple(statements, batch_size=1)
+
+        statement_1_first_row = response[0][0]
+        self.assertEqual(statement_1_first_row['key-cypher-1'], 'value-cypher-1')
+
+        statement_2_first_row = response[1][0]
+        self.assertEqual(statement_2_first_row['key-cypher-2'], 'value-cypher-2')
+
+        # check that post has been called 2 times (i.e. 2 batches of a single statement per post request)
+        self.assertEqual(mock_get.call_count, 2)


### PR DESCRIPTION
Sometime it's desirable to split a large list of statements into smaller batches so that Neo4j doesn't get overwhelmed. This pull request makes it easy to split the statements into batches by passing the maximum number of statement allowed per POST request