### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.txt


### PR DESCRIPTION
Include missing files in sdist for #5

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.45wE82mOxw
+ trap 'rm -rf /tmp/tmp.45wE82mOxw' EXIT
+ python -m venv /tmp/tmp.45wE82mOxw
+ python setup.py sdist -d /tmp/tmp.45wE82mOxw
running sdist
running egg_info
writing neo4j_connector.egg-info/PKG-INFO
writing dependency_links to neo4j_connector.egg-info/dependency_links.txt
writing requirements to neo4j_connector.egg-info/requires.txt
writing top-level names to neo4j_connector.egg-info/top_level.txt
reading manifest file 'neo4j_connector.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'neo4j_connector.egg-info/SOURCES.txt'
running check
creating neo4j-connector-1.1.0
creating neo4j-connector-1.1.0/neo4j
creating neo4j-connector-1.1.0/neo4j_connector.egg-info
copying files to neo4j-connector-1.1.0...
copying MANIFEST.in -> neo4j-connector-1.1.0
copying README.rst -> neo4j-connector-1.1.0
copying requirements.txt -> neo4j-connector-1.1.0
copying setup.py -> neo4j-connector-1.1.0
copying neo4j/__init__.py -> neo4j-connector-1.1.0/neo4j
copying neo4j_connector.egg-info/PKG-INFO -> neo4j-connector-1.1.0/neo4j_connector.egg-info
copying neo4j_connector.egg-info/SOURCES.txt -> neo4j-connector-1.1.0/neo4j_connector.egg-info
copying neo4j_connector.egg-info/dependency_links.txt -> neo4j-connector-1.1.0/neo4j_connector.egg-info
copying neo4j_connector.egg-info/requires.txt -> neo4j-connector-1.1.0/neo4j_connector.egg-info
copying neo4j_connector.egg-info/top_level.txt -> neo4j-connector-1.1.0/neo4j_connector.egg-info
Writing neo4j-connector-1.1.0/setup.cfg
Creating tar archive
removing 'neo4j-connector-1.1.0' (and everything under it)
+ cd /
+ /tmp/tmp.45wE82mOxw/bin/pip install /tmp/tmp.45wE82mOxw/neo4j-connector-1.1.0.tar.gz
Processing /tmp/tmp.45wE82mOxw/neo4j-connector-1.1.0.tar.gz
Collecting requests<3.0,>=2.0 (from neo4j-connector==1.1.0)
  Using cached https://files.pythonhosted.org/packages/1a/70/1935c770cb3be6e3a8b78ced23d7e0f3b187f5cbfab4749523ed65d7c9b1/requests-2.23.0-py2.py3-none-any.whl
Collecting idna<3,>=2.5 (from requests<3.0,>=2.0->neo4j-connector==1.1.0)
  Using cached https://files.pythonhosted.org/packages/89/e3/afebe61c546d18fb1709a61bee788254b40e736cff7271c7de5de2dc4128/idna-2.9-py2.py3-none-any.whl
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 (from requests<3.0,>=2.0->neo4j-connector==1.1.0)
  Using cached https://files.pythonhosted.org/packages/e1/e5/df302e8017440f111c11cc41a6b432838672f5a70aa29227bf58149dc72f/urllib3-1.25.9-py2.py3-none-any.whl
Collecting chardet<4,>=3.0.2 (from requests<3.0,>=2.0->neo4j-connector==1.1.0)
  Using cached https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl
Collecting certifi>=2017.4.17 (from requests<3.0,>=2.0->neo4j-connector==1.1.0)
  Using cached https://files.pythonhosted.org/packages/57/2b/26e37a4b034800c960a00c4e1b3d9ca5d7014e983e6e729e33ea2f36426c/certifi-2020.4.5.1-py2.py3-none-any.whl
Installing collected packages: idna, urllib3, chardet, certifi, requests, neo4j-connector
  Running setup.py install for neo4j-connector: started
    Running setup.py install for neo4j-connector: finished with status 'done'
Successfully installed certifi-2020.4.5.1 chardet-3.0.4 idna-2.9 neo4j-connector-1.1.0 requests-2.23.0 urllib3-1.25.9
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.45wE82mOxw
```
